### PR TITLE
Fix createInvalidation requests with multiple paths

### DIFF
--- a/src/CloudFrontPurger.php
+++ b/src/CloudFrontPurger.php
@@ -234,7 +234,7 @@ class CloudFrontPurger extends BaseCachePurger
                     'CallerReference' => time(),
                     'Paths' => [
                         'Items' => $paths,
-                        'Quantity' => 1,
+                        'Quantity' => count($paths),
                     ],
                 ]
             ]);


### PR DESCRIPTION
According to [AWS documentation](https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-cloudfront-2020-05-31.html#shape-paths), `Quantity` should match the number of `Items`.