### PR TITLE
Gracefully handle AWS client exceptions

### DIFF
--- a/src/CloudFrontPurger.php
+++ b/src/CloudFrontPurger.php
@@ -242,7 +242,10 @@ class CloudFrontPurger extends BaseCachePurger
             ]);
         }
         catch (AwsException $exception) {
-            Blitz::$plugin->log($exception->getAwsErrorMessage(), [], 'error');
+            $errorCode = $exception->getAwsErrorCode() ?: 'Not provided.';
+            $errorMessage = $exception->getAwsErrorMessage() ?: 'Not provided.';
+            $error = "AWS Client Error - Code: {$errorCode} - Message: {$errorMessage}";
+            Blitz::$plugin->log($error, [], 'error');
 
             return false;
         }


### PR DESCRIPTION
AWS may return a null error message. `Blitz::$plugin->log()` requires a
string, so passing the error message (which may be null) directly can
lead to an unexpected error.

@bencroker - This error has been observed preventing a successful
application of Project Config updates, which means that it potentially
breaks automated deployments.