### PR TITLE
URL-encode invalidation paths

### DIFF
--- a/src/CloudFrontPurger.php
+++ b/src/CloudFrontPurger.php
@@ -145,7 +145,7 @@ class CloudFrontPurger extends BaseCachePurger
         $paths = [];
 
         foreach ($event->siteUris as $siteUri) {
-            $paths[] = '/' . $siteUri->uri;
+            $paths[] = '/' . str_replace('%2F', '/', urlencode($siteUri->uri));
         }
 
         $this->_sendRequest($paths);

--- a/src/CloudFrontPurger.php
+++ b/src/CloudFrontPurger.php
@@ -141,12 +141,15 @@ class CloudFrontPurger extends BaseCachePurger
             return;
         }
 
-        // Get paths from site URIs (https://github.com/putyourlightson/craft-blitz-cloudfront/issues/1)
-        $paths = [];
+        $reservedCharacters = [";", "/", "?", ":", "@", "=", "&"];
+        $encodedReservedCharacters = array_map(function($c) {
+            return urlencode($c);
+        }, $reservedCharacters);
 
-        foreach ($event->siteUris as $siteUri) {
-            $paths[] = '/' . str_replace('%2F', '/', urlencode($siteUri->uri));
-        }
+        // Get paths from site URIs (https://github.com/putyourlightson/craft-blitz-cloudfront/issues/1)
+        $paths = array_map(function($siteUri) use ($encodedReservedCharacters, $reservedCharacters) {
+            return '/' . str_replace($encodedReservedCharacters, $reservedCharacters, urlencode($siteUri->uri));
+        }, $event->siteUris);
 
         $this->_sendRequest($paths);
 


### PR DESCRIPTION
CloudFront expects special characters in invalidation paths to be url-encoded.  This update replaces all non-slash characters in the path with their url-encoded values.