### PR TITLE
Add wildcard character * to reserved characters

### DIFF
--- a/src/CloudFrontPurger.php
+++ b/src/CloudFrontPurger.php
@@ -199,8 +199,8 @@ class CloudFrontPurger extends BaseCachePurger
         // Revert encoded reserved characters back to their original values.
         // https://github.com/putyourlightson/craft-blitz-cloudfront/pull/6
         // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html#invalidation-specifying-objects
-        $reservedCharacters = [';', '/', '?', ':', '@', '=', '&'];
-        $encodedReservedCharacters = ['%3B', '%2F', '%3F', '%3A', '%40', '%3D', '%26'];
+        $reservedCharacters = [';', '/', '?', ':', '@', '=', '&', '*'];
+        $encodedReservedCharacters = ['%3B', '%2F', '%3F', '%3A', '%40', '%3D', '%26', '%2A'];
         $path = str_replace($encodedReservedCharacters, $reservedCharacters, urlencode($path));
 
         // Append a trailing slash if `addTrailingSlashesToUrls` is `true`.


### PR DESCRIPTION
I wrote a utility for a client to manually purge cache from CloudFront, but was noticing the wildcard character got encoded and was therefore not working as expected. Adding the character to the `$reservedCharacters` array to restore it to its original value solved that issue for me.