### PR TITLE
Extract path from constructed site URL to include path prefix

### DIFF
--- a/src/CloudFrontPurger.php
+++ b/src/CloudFrontPurger.php
@@ -150,7 +150,7 @@ class CloudFrontPurger extends BaseCachePurger
         // Revert encoded reserved characters back to their original values.
         // https://github.com/putyourlightson/craft-blitz-cloudfront/pull/6
         $paths = array_map(function($siteUri) use ($encodedReservedCharacters, $reservedCharacters) {
-            return '/' . str_replace($encodedReservedCharacters, $reservedCharacters, urlencode($siteUri->uri));
+            return str_replace($encodedReservedCharacters, $reservedCharacters, urlencode(parse_url($siteUri->getUrl(), PHP_URL_PATH)));
         }, $event->siteUris);
 
         // Append a trailing slash if `addTrailingSlashesToUrls` is `true`.


### PR DESCRIPTION
Invalidation requests don’t work as expected when a site’s `primaryUrl` has a path prefix. For example, when a site’s `primaryUrl` is `https://example.com/es`, attempting to purge `https://example.com/es/webpage` creates an invalidation request for `/webpage` instead of `/es/webpage`.

This change extracts the path component from a fully formed URL to ensure the path prefix is included.

We need this in `v2` for sites not yet on Craft 4.